### PR TITLE
Update set-output command to new GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -23,7 +23,7 @@ jobs:
       continue-on-error: true
       run: |
         OUTPUT=$(git show -q | grep "Bump version from" | awk '{print $6}') &&
-        echo "::set-output name=OUTPUT::$OUTPUT"
+        echo "OUTPUT=$OUTPUT" >> $GITHUB_OUTPUT
     - name: Git tag & push
       if: steps.version_number.outputs.OUTPUT != ''
       run: |


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/